### PR TITLE
Fixing IDENTITY-4629

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso.ui/src/main/resources/META-INF/component.xml
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso.ui/src/main/resources/META-INF/component.xml
@@ -26,6 +26,7 @@
                 <skip-link>../sso-acs/redirect_ajaxprocessor.jsp</skip-link>
                 <skip-link>../sso-acs/notifications.jsp</skip-link>
                 <skip-link>../sso-acs/authFailure.jsp</skip-link>
+                <skip-link>/carbon/sso-acs/authFailure.jsp</skip-link>
                 <skip-link>/acs</skip-link>
             </skip-authentication>
         </menu>


### PR DESCRIPTION
Avoid showing a blank page for invalid credentials in carbon SAML login