### PR TITLE
Preventing SAML XML Signature Wrapping Attacks

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
@@ -29,6 +29,7 @@ import org.opensaml.saml2.core.Audience;
 import org.opensaml.saml2.core.AudienceRestriction;
 import org.opensaml.saml2.core.Conditions;
 import org.opensaml.saml2.core.Response;
+import org.opensaml.security.SAMLSignatureProfileValidator;
 import org.opensaml.xml.XMLObject;
 import org.opensaml.xml.signature.Signature;
 import org.opensaml.xml.signature.SignatureValidator;
@@ -411,7 +412,10 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
     private boolean validateSignature(Signature signature, String domainName) {
         boolean isSignatureValid = false;
         try {
-            SignatureValidator validator = null;
+            SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
+            signatureProfileValidator.validate(signature);
+
+            SignatureValidator validator;
             if (isVerifySignWithUserDomain()) {
                 validator = new SignatureValidator(Util.getX509CredentialImplForTenant(domainName));
             } else {

--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
@@ -411,6 +411,9 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
         if (response == null || response.getSignature() == null) {
             log.error("SAML Response is not signed or response not available. Authentication process will be terminated.");
         } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Validating SAML Response Signature.");
+            }
             isSignatureValid = validateSignature(response.getSignature(), domainName);
         }
         return isSignatureValid;
@@ -428,6 +431,9 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
         if (assertion == null || assertion.getSignature() == null) {
             log.error("SAML Assertion is not signed or assertion not available. Authentication process will be terminated.");
         } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Validating SAML Assertion Signature.");
+            }
             isSignatureValid = validateSignature(assertion.getSignature(), domainName);
         }
         return isSignatureValid;
@@ -458,7 +464,9 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
             String errorMsg = "Error when creating an X509CredentialImpl instance";
             log.error(errorMsg, e);
         } catch (ValidationException e) {
-            log.warn("Signature validation failed for a SAML2 Reposnse from domain : " + domainName, e);
+            if (log.isDebugEnabled()) {
+                log.debug("SAML Signature validation failed from domain : " + domainName, e);
+            }
         }
         return isSignatureValid;
     }

--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
@@ -383,25 +383,20 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
      */
     private boolean validateSignature(XMLObject xmlObject, String domainName) {
 
-        boolean isValid;
         if (xmlObject instanceof Response) {
             Response response = (Response) xmlObject;
-            boolean isValidResponseSignature =
-                    isResponseSignatureValidationEnabled() ? validateSignature(response, domainName) : true;
-            boolean isValidAssertionSignature = isAssertionSignatureValidationEnabled() ?
-                                                validateSignature(getAssertionFromResponse(response), domainName) :
-                                                true;
-
-            isValid = isValidResponseSignature && isValidAssertionSignature;
+            if (isResponseSignatureValidationEnabled() ? validateSignature(response, domainName) : true) {
+                return isAssertionSignatureValidationEnabled() ?
+                       validateSignature(getAssertionFromResponse(response), domainName) : true;
+            }
         } else if (xmlObject instanceof Assertion) {
-            isValid = isAssertionSignatureValidationEnabled() ? validateSignature((Assertion) xmlObject, domainName) :
-                      true;
+            return isAssertionSignatureValidationEnabled() ? validateSignature((Assertion) xmlObject, domainName) :
+                   true;
         } else {
-            isValid = false;
             log.error("Only Response and Assertion objects are validated in this authenticator");
         }
 
-        return isValid;
+        return false;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticatorBEConstants.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticatorBEConstants.java
@@ -32,6 +32,7 @@ public class SAML2SSOAuthenticatorBEConstants {
         }
         public static final String AUTH_CONFIG_PARAM_IDP_CERT_ALIAS = "IdPCertAlias";
         public static final String RESPONSE_SIGNATURE_VALIDATION_ENABLED = "ResponseSignatureValidationEnabled";
+        public static final String ASSERTION_SIGNATURE_VALIDATION_ENABLED = "AssertionSignatureValidationEnabled";
         public static final String VALIDATE_SIGNATURE_WITH_USER_DOMAIN = "VerifySignatureWithUserDomain";
         public static final String ROLE_CLAIM_ATTRIBUTE = "RoleClaimAttribute";
         public static final String ATTRIBUTE_VALUE_SEPARATOR = "AttributeValueSeparator";


### PR DESCRIPTION
Ensured that at first the signature is validated with org.opensaml.security.SAMLSignatureProfileValidator as recommended. This will ensure that the signature follows the standard for XML signatures, and will avoid certain types of DoS attacks associated with the signature.
Added support to enable or disable assertion signature validation from the authenticator configurations in authenticators.xml since in a recent improvement [1] assertion signature validation was enforced. Previously assertion signature was not validated anyway.
With this fix, if explicitly not disabled from the configuration both assertion signature validation and response signature validation will be enforced by default.
[1] https://github.com/wso2-extensions/identity-carbon-auth-saml2/pull/13