### PR TITLE
Clear domain from ThreadLocal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+jdk:
+    - oraclejdk8
+cache:
+  directories:
+  - .autoconf
+  - $HOME/.m2
+script: mvn clean install

--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.AuthenticationObserver;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -159,6 +160,7 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
                         "/permission/admin/login", CarbonConstants.UI_PERMISSION_ACTION);
             }
             if (isAuthorized) {
+                UserCoreUtil.setDomainInThreadLocal(null);
                 CarbonAuthenticationUtil.onSuccessAdminLogin(httpSession, username,
                         tenantId, tenantDomain, "SAML2 SSO Authentication");
                 handleAuthenticationCompleted(tenantId, true);


### PR DESCRIPTION
We need to clear the user domain in threadLocal. Otherwise the wrong user domain will be pick from certain other locations e.g. https://github.com/wso2/carbon-kernel/blob/v4.4.4/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java#L92

Fixes https://github.com/wso2/product-is/issues/2307