### PR TITLE
Add missed import package.

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/pom.xml
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/pom.xml
@@ -120,6 +120,7 @@
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.base; version="${identity.framework.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util.*; version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.authenticator.saml2.sso.common; version="${identity.carbon.auth.saml2.package.import.version.range}",
                             org.wso2.carbon.identity.saml.common.util.*; version="${saml.common.util.version.range}",
                             org.joda.time; version="${joda.wso2.osgi.version.range}"


### PR DESCRIPTION
- Added missed import package: `org.wso2.carbon.identity.core.util.*; version="${identity.framework.package.import.version.range}",`

- Fixes no class def which occurs while trying SSO between wso2 products.