### PR TITLE
Update opensaml version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
     </modules>
 
     <properties>
-        <opensaml2.wso2.version>3.3.1.wso2v1</opensaml2.wso2.version>
+        <opensaml2.wso2.version>3.3.1.wso2v2</opensaml2.wso2.version>
         <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
         <wss4j.version>1.5.11.wso2v15</wss4j.version>
         <wss4j.xml.security.imp.pkg.version.range>[1.4.2.patched,2.0.0)</wss4j.xml.security.imp.pkg.version.range>


### PR DESCRIPTION
Partially fixes https://github.com/wso2/product-is/issues/9984
 
This PR will update the opensaml version and avoid opensaml 3.3.1.wso2v1 getting packed in the product-is.