### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,9 +261,9 @@
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <identity.framework.version>5.15.0</identity.framework.version>
-        <identity.framework.package.import.version.range>[5.15.0, 6.0.0)</identity.framework.package.import.version.range>
-        <identity.carbon.auth.saml2.package.import.version.range>[5.4.0, 6.0.0)</identity.carbon.auth.saml2.package.import.version.range>
+        <identity.framework.version>6.0.0</identity.framework.version>
+        <identity.framework.package.import.version.range>[6.0.0, 7.0.0)</identity.framework.package.import.version.range>
+        <identity.carbon.auth.saml2.package.import.version.range>[6.0.0, 7.0.0)</identity.carbon.auth.saml2.package.import.version.range>
         <identity.carbon.auth.saml2.package.export.version>${project.version}</identity.carbon.auth.saml2.package.export.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <servlet-api.version>2.5</servlet-api.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16