### PR TITLE
Bump opensaml version to 3.3.1.wso2v11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
     </modules>
 
     <properties>
-        <opensaml2.wso2.version>3.3.1.wso2v7</opensaml2.wso2.version>
+        <opensaml2.wso2.version>3.3.1.wso2v11</opensaml2.wso2.version>
         <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
         <wss4j.version>1.5.11.wso2v15</wss4j.version>
         <wss4j.xml.security.imp.pkg.version.range>[2.1.7,2.4.0)</wss4j.xml.security.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
     </modules>
 
     <properties>
-        <opensaml2.wso2.version>3.3.1.wso2v11</opensaml2.wso2.version>
+        <opensaml2.wso2.version>3.3.1.wso2v7</opensaml2.wso2.version>
         <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
         <wss4j.version>1.5.11.wso2v15</wss4j.version>
         <wss4j.xml.security.imp.pkg.version.range>[2.1.7,2.4.0)</wss4j.xml.security.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
- $suject
- From this PR the below dependencies are upgraded in the opensaml orbit jar
     - apache commons codec version from 1.10 to 1.16
     - esapi.version from 2.4.0.0 to 2.5.3.1
     - org.apache.xml.security.version range