### PR TITLE
Preserve application roles during deletion in SAML2 SSO authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticator.java
@@ -75,6 +75,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Iterator;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -704,6 +705,20 @@ public class SAML2SSOAuthenticator implements CarbonServerAuthenticator {
 
                     // Exclude Internal/everyonerole from deleting role since its cannot be deleted
                     deletingRoles.remove(realm.getRealmConfiguration().getEveryOneRoleName());
+
+                    // Exclude Application roles from deleting roles as they need to be preserved
+                    List<String> preservedApplicationRoles = new ArrayList<>();
+                    Iterator<String> iterator = deletingRoles.iterator();
+                    while (iterator.hasNext()) {
+                        String role = iterator.next();
+                        if (role != null && role.startsWith(SAML2SSOAuthenticatorBEConstants.SAML2_SSO_APPLICATION_ROLE_PREFIX)) {
+                            preservedApplicationRoles.add(role);
+                            iterator.remove();
+                        }
+                    }
+                    if (log.isDebugEnabled() && !preservedApplicationRoles.isEmpty()) {
+                        log.debug("Preserved Application roles from deletion: " + preservedApplicationRoles);
+                    }
 
                     // Check for case whether superadmin login
                     if (userstore.getRealmConfiguration().isPrimary() && username.equals(realm.getRealmConfiguration().getAdminUserName())) {

--- a/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticatorBEConstants.java
+++ b/components/org.wso2.carbon.identity.authenticator.saml2.sso/src/main/java/org/wso2/carbon/identity/authenticator/saml2/sso/SAML2SSOAuthenticatorBEConstants.java
@@ -25,6 +25,7 @@ public class SAML2SSOAuthenticatorBEConstants {
     public static final String ROLE_ATTRIBUTE_NAME = "http://wso2.org/claims/role";
     public static final String ATTRIBUTE_VALUE_SEPERATER = ",";
 
+    public static final String SAML2_SSO_APPLICATION_ROLE_PREFIX = "Application/";
 
     public class PropertyConfig {
         private PropertyConfig(){


### PR DESCRIPTION
## 🔧 Preserve Application Roles During SAML2 SSO Login

### 🐞 Issue Description

In **WSO2 API Manager**, when users log in to the **Management Console (Carbon Console)** via **SAML federated login**, the authenticator (`SAML2SSOAuthenticator.java`) removes all existing user roles during provisioning — including essential **Application roles** staring with `Application/`.

This behavior causes users to **lose access** to Developer Portal functionalities, such as viewing or generating application keys, and managing applications in the Management Console. The roles need to be manually reassigned after each login, which is not feasible in production setups. 

🔗 Issue Link

- https://github.com/wso2/api-manager/issues/3992

🛠️ Fix Approach

To resolve this, the fix directly modifies the `SAML2SSOAuthenticator` logic to preserve roles that start with `Application/` — preventing them from being removed during role provisioning. This ensures users retain access to their applications and related functionality after each SSO login.

✅ What’s done:

Iterates over the `deletingRoles` list and removes any role starting with `"Application/"` before deletion occurs.

> This PR fixes an issue that occurs only when SAML2 SSO login is configured for the Management Portal **and** the `enable_role_validation` configuration under `application_mgt` is set according to the [IS 6.0.0 migration documentation](https://github.com/wso2-enterprise/migration-docs/blob/main/identity-server/migration-docs/is-6.0.0/what-has-changed.md#application-management).

### Related PRs

- https://github.com/wso2-support/identity-carbon-auth-saml2/pull/60