### PR TITLE
[5.8.x] Upgrade axis2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,8 +280,8 @@
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
 
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
-        <axis2.osgi.version.range>[1.6.1.wso2v105, 2.0.0)</axis2.osgi.version.range>
-        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
+        <axis2.osgi.version.range>[1.6.1, 2.0.0)</axis2.osgi.version.range>
+        <axis2.wso2.version>1.6.1-wso2v108</axis2.wso2.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2.0,2.0.0)</commons-logging.osgi.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates the Axis2 dependency versions in the `pom.xml` file to use newer releases and removes the WSO2-specific version constraints. These changes help ensure compatibility with newer libraries and may resolve issues with outdated dependencies.

Dependency version updates:

* Changed `axis2.osgi.version.range` to remove the WSO2-specific qualifier, now allowing versions from `1.6.1` up to (but not including) `2.0.0`.
* Updated `axis2.wso2.version` from `1.6.1-wso2v105` to `1.6.1-wso2v108` to use a newer WSO2 build.